### PR TITLE
Fix preferences window crash

### DIFF
--- a/src/ui/prefs_win.glade
+++ b/src/ui/prefs_win.glade
@@ -63,8 +63,6 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="font"/>
-                <property name="language">en-gb</property>
-                <property name="level">GTK_FONT_CHOOSER_LEVEL_SIZE | GTK_FONT_CHOOSER_LEVEL_FAMILY</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>


### PR DESCRIPTION
Closes #107.

Basically just removing some properties from the GtkFontChooserWidget which cause a crash (seemingly in older GTK3 versions)