### PR TITLE
feat(edit_view): use Popover to make the FindReplace Dialog smaller

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ license = "MIT"
 edition = "2018"
 readme = "README.md"
 
+[features]
+default = []
+
+gtk_v3_22 = ["gtk/v3_22"]
+
 [dependencies]
 cairo-rs = "0.6"
 env_logger = "0.6"

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,8 @@ dependency('gio-2.0', version: '>= 2.38')
 dependency('cairo', version: '>= 1')
 dependency('pango', version: '>=1.38')
 dependency('gtk+-3.0', version: '>= 3.20')
+# This is only used to decide what transition code to use for the search/replace Popover
+opt_gtk3_22_dep = dependency('gtk+-3.0', version: '>= 3.22', required: false)
 
 gxi_prefix = get_option('prefix')
 gxi_bindir = join_paths(gxi_prefix, get_option('bindir'))
@@ -36,6 +38,12 @@ else
   cross_build='false'
 endif
 
+if opt_gtk3_22_dep.found()
+  gtk3_22='true'
+else
+  gtk3_22='false'
+endif
+
 custom_target('cargo-build-gxi',
                         build_by_default: true,
                         build_always_stale: true,
@@ -51,6 +59,7 @@ custom_target('cargo-build-gxi',
                                   meson.current_build_dir(),
                                   'gxi',
                                   cross_build,
+                                  gtk3_22,
                                   gxi_plugin_dir,
                                   gxi_localedir,
                                   meson.project_version(),
@@ -93,6 +102,10 @@ custom_target('cargo-build-syntect',
                                   syntect_releasebin_path,
                                   'xi-syntect-plugin',
                                   cross_build,
+                                  '',
+                                  gxi_plugin_dir,
+                                  gxi_localedir,
+                                  meson.project_version(),
                                  ])
 
 synctect_assets = ['assets/Makefile.toml', 'assets/YAML.toml', 'manifest.toml']

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -1,20 +1,18 @@
 #!/bin/sh
 
-export GXI_PLUGIN_DIR=$7
-export GXI_LOCALEDIR=$8
-export GXI_APP_ID="com.github.Cogitri.gxi"
-export GXI_VERSION=$9
+export GXI_PLUGIN_DIR=$8
+export GXI_LOCALEDIR=$9
+export GXI_VERSION=$10
 
 export GREEN='\033[0;32m'
 export NO_COLOR='\033[0m'
 
 echo "\tGXI Plugindir: ${GREEN}${GXI_PLUGIN_DIR}${NO_COLOR}
-\tGXI Localedir: ${GREEN}${GXI_LOCALEDIR}${NO_COLOR}
-\tGXI App-ID:    ${GREEN}${GXI_APP_ID}${NO_COLOR}
-\tGXI Version:   ${GREEN}${GXI_VERSION}${NO_COLOR}
-\tCrossbuild:    ${GREEN}${6}
+\tGXI Localedir:       ${GREEN}${GXI_LOCALEDIR}${NO_COLOR}
+\tGXI Version:         ${GREEN}${GXI_VERSION}${NO_COLOR}
+\tCrossbuild:          ${GREEN}${6}${NO_COLOR}
+\tDetected GTK+3.22:   ${GREEN}${7}${NO_COLOR}
 "
-
 
 cd $1
 if [ "$6" = "true" ]; then
@@ -22,4 +20,8 @@ if [ "$6" = "true" ]; then
 else
     path="${4}/release/${5}"
 fi
-cargo build --target-dir $4 --release && cp "${path}" $2/$3
+if [ "$7" = "true" ]; then
+    features="--features gtk_v3_22"
+fi
+
+cargo build --target-dir $4 --release ${features} && cp "${path}" $2/$3

--- a/src/about_win.rs
+++ b/src/about_win.rs
@@ -30,7 +30,7 @@ impl AboutWin {
         trace!("{}", gettext("Showing about window"));
         about_dialog.show_all();
 
-        Rc::new(RefCell::new(AboutWin {
+        Rc::new(RefCell::new(Self {
             about_dialog: about_dialog.clone(),
         }))
     }

--- a/src/edit_view.rs
+++ b/src/edit_view.rs
@@ -969,7 +969,7 @@ impl EditView {
         // Set the appropriate size for the linecount DrawingArea, otherwise it's only 1 px wide.
         self.view_item
             .linecount
-            .set_size_request(linecount_width as i32, linecount_height);
+            .set_size_request(linecount_width as i32, -1);
         Inhibit(false)
     }
 

--- a/src/edit_view.rs
+++ b/src/edit_view.rs
@@ -333,6 +333,7 @@ impl FindReplace {
         let show_options_button = builder.get_object("show_options_button").unwrap();
 
         popover.set_position(PositionType::Bottom);
+        #[cfg(not(feature = "gtk_v3_22"))]
         popover.set_transitions_enabled(true);
         popover.set_relative_to(btn);
 
@@ -1485,6 +1486,9 @@ impl EditView {
             }
         } else {
             self.find_replace.search_bar.set_search_mode(true);
+            #[cfg(feature = "gtk_v3_22")]
+            self.find_replace.popover.popup();
+            #[cfg(not(feature = "gtk_v3_22"))]
             self.find_replace.popover.show();
             self.find_replace
                 .option_revealer
@@ -1518,6 +1522,9 @@ impl EditView {
         } else {
             self.find_replace.show_replace_button.set_active(true);
             self.find_replace.search_bar.set_search_mode(true);
+            #[cfg(feature = "gtk_v3_22")]
+            self.find_replace.popover.popup();
+            #[cfg(not(feature = "gtk_v3_22"))]
             self.find_replace.popover.show();
             self.find_replace
                 .option_revealer
@@ -1551,6 +1558,9 @@ impl EditView {
 
     /// Closes the find/replace dialog
     pub fn stop_search(&self) {
+        #[cfg(feature = "gtk_v3_22")]
+        self.find_replace.popover.popdown();
+        #[cfg(not(feature = "gtk_v3_22"))]
         self.find_replace.popover.hide();
         self.find_replace.show_replace_button.set_active(false);
         self.find_replace.show_options_button.set_active(false);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -71,13 +71,11 @@ impl ErrorDialog {
             }
         }));
 
+        err_dialog.show_all();
+
         Self {
             dialog: err_dialog,
             msg: err_msg,
         }
-    }
-
-    pub fn show_all(&self) {
-        self.dialog.show_all();
     }
 }

--- a/src/linecache.rs
+++ b/src/linecache.rs
@@ -59,7 +59,7 @@ impl Line {
                 styles.push(style_span);
             }
         }
-        Line {
+        Self {
             text,
             cursor,
             styles,

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,7 @@ use crate::main_win::MainWin;
 use crate::pref_storage::Config;
 use crate::rpc::Core;
 use crate::shared_queue::{CoreMsg, SharedQueue};
+use crate::xi_thread::XiPeer;
 use gettextrs::{gettext, TextDomain, TextDomainError};
 use gio::{ApplicationExt, ApplicationExtManual, ApplicationFlags, FileExt};
 use glib::MainContext;
@@ -119,7 +120,7 @@ fn main() {
 
     let (err_tx, err_rx) = MainContext::channel::<ErrorMsg>(glib::PRIORITY_DEFAULT_IDLE);
 
-    let (xi_peer, xi_rx) = xi_thread::start_xi_thread();
+    let (xi_peer, xi_rx) = XiPeer::new();
     let core = Core::new(xi_peer, xi_rx, err_tx, shared_queue.clone());
 
     let application = Application::new(crate::globals::APP_ID, ApplicationFlags::HANDLES_OPEN)

--- a/src/main_win.rs
+++ b/src/main_win.rs
@@ -552,8 +552,7 @@ impl MainWin {
                     gettext("functionality will be limited")
                 ),
                 fatal: false,
-            })
-            .show_all();
+            });
         }
     }
 
@@ -640,7 +639,7 @@ impl MainWin {
                         Ok(_) => win.req_new_view(Some(&file_str)),
                         Err(e) => {
                             let err_msg = format!("{} '{}': {}", &gettext("Couldn't open file"), &file_str, &e.to_string());
-                            ErrorDialog::new(ErrorMsg{msg: err_msg, fatal: false}).show_all();
+                            ErrorDialog::new(ErrorMsg{msg: err_msg, fatal: false});
                         }
                     }
                 }
@@ -704,7 +703,7 @@ impl MainWin {
                             }
                         Err(e) => {
                             let err_msg = format!("{} '{}': {}", &gettext("Couldn't save file"), &file_str, &e.to_string());
-                            ErrorDialog::new(ErrorMsg {msg: err_msg, fatal: false}).show_all();
+                            ErrorDialog::new(ErrorMsg {msg: err_msg, fatal: false});
                         }
                     }
                 }

--- a/src/main_win.rs
+++ b/src/main_win.rs
@@ -268,11 +268,11 @@ impl MainWin {
             quit_action.connect_activate(clone!(main_win => move |_,_| {
                 trace!("{} 'quit' {}", gettext("Handling"), gettext("action"));
                 // Same as in connect_destroy, only quit if the user saves or wants to close without saving
-                if Self::close_all(main_win.clone()) != SaveAction::Cancel {
+                if Self::close_all(main_win.clone()) == SaveAction::Cancel {
+                    debug!("{}", gettext("User chose to not quit application"));
+                } else {
                     debug!("{}", gettext("User chose to quit application"));
                     main_win.borrow().window.destroy();
-                } else {
-                    debug!("{}", gettext("User chose to not quit application"));
                 }
             }));
             application.add_action(&quit_action);
@@ -794,7 +794,7 @@ impl MainWin {
         if let Some(view_id) = value.as_str() {
             let hamburger_button = win.builder.get_object("hamburger_button").unwrap();
             let edit_view =
-                EditView::new(&win.state, &win.core, hamburger_button, file_name, view_id);
+                EditView::new(&win.state, &win.core, &hamburger_button, file_name, view_id);
             {
                 let ev = edit_view.borrow();
                 let page_num =

--- a/src/main_win.rs
+++ b/src/main_win.rs
@@ -792,7 +792,9 @@ impl MainWin {
             .for_each(|lang| syntax_combo_box.append_text(lang));
 
         if let Some(view_id) = value.as_str() {
-            let edit_view = EditView::new(&win.state, &win.core, file_name, view_id);
+            let hamburger_button = win.builder.get_object("hamburger_button").unwrap();
+            let edit_view =
+                EditView::new(&win.state, &win.core, hamburger_button, file_name, view_id);
             {
                 let ev = edit_view.borrow();
                 let page_num =

--- a/src/pref_storage.rs
+++ b/src/pref_storage.rs
@@ -159,7 +159,7 @@ impl Config {
                 .unwrap()
                 .into_path();
 
-            let xi_config = Config {
+            let xi_config = Self {
                 config: XiConfig::default(),
                 path: config_dir
                     .join("preferences.xiconfig")

--- a/src/prefs_win.rs
+++ b/src/prefs_win.rs
@@ -19,7 +19,7 @@ impl PrefsWin {
         parent: &ApplicationWindow,
         main_state: &Rc<RefCell<MainState>>,
         core: &Rc<RefCell<Core>>,
-        edit_view: &Rc<RefCell<EditView>>,
+        edit_view: Option<Rc<RefCell<EditView>>>,
     ) -> Rc<RefCell<Self>> {
         const SRC: &str = include_str!("ui/prefs_win.glade");
         let builder = Builder::new_from_string(SRC);
@@ -163,7 +163,9 @@ impl PrefsWin {
                     let value = toggle_btn.get_active();
                     debug!("{}: {}", gettext("Right hand margin"), value);
                     set_draw_right_margin(value);
-                    edit_view.borrow().view_item.edit_area.queue_draw();
+                    if let Some(ev) = edit_view.clone() {
+                        ev.borrow().view_item.edit_area.queue_draw();
+                    }
                     margin_spinbutton.set_sensitive(value);
                 }),
             );
@@ -177,7 +179,9 @@ impl PrefsWin {
                 let value = spin_btn.get_value();
                 debug!("{}: {}", gettext("Right hand margin width"), value);
                 set_column_right_margin(value as u32);
-                edit_view.borrow().view_item.edit_area.queue_draw();
+                if let Some(ev) = edit_view.clone() {
+                    ev.borrow().view_item.edit_area.queue_draw();
+                }
             }));
         }
 
@@ -187,7 +191,9 @@ impl PrefsWin {
             highlight_line_checkbutton.connect_toggled(clone!(edit_view => move |toggle_btn| {
                 let value = toggle_btn.get_active();
                 set_highlight_line(value);
-                edit_view.borrow().view_item.edit_area.queue_draw();
+                if let Some(ev) = edit_view.clone() {
+                    ev.borrow().view_item.edit_area.queue_draw();
+                }
             }));
         }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -478,7 +478,14 @@ impl Core {
     ///
     /// If `chars` is `None` and there is an active selection, returns
     /// the string value used for the search, else returns `Null`.
-    pub fn find(&self, view_id: &str, chars: &str, case_sensitive: bool, regex: Option<bool>) {
+    pub fn find(
+        &self,
+        view_id: &str,
+        chars: &str,
+        case_sensitive: bool,
+        regex: bool,
+        whole_words: bool,
+    ) {
         self.send_edit_cmd(
             view_id,
             "find",
@@ -486,6 +493,7 @@ impl Core {
                 "chars": chars,
                 "case_sensitive": case_sensitive,
                 "regex": regex,
+                "whole_words": whole_words,
             }),
         )
     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -29,7 +29,7 @@ pub trait Callback: Send {
 }
 
 impl<F: FnOnce(&Value) + Send> Callback for F {
-    fn call(self: Box<F>, result: &Value) {
+    fn call(self: Box<Self>, result: &Value) {
         (*self)(result)
     }
 }

--- a/src/ui/find_replace.glade
+++ b/src/ui/find_replace.glade
@@ -1,158 +1,115 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.10"/>
-  <object class="GtkSearchBar" id="search_bar">
-    <property name="visible">True</property>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkPopover" id="search_popover">
     <property name="can_focus">False</property>
-    <property name="valign">start</property>
-    <property name="hexpand">True</property>
-    <property name="show_close_button">True</property>
     <child>
-      <object class="GtkBox">
+      <object class="GtkSearchBar" id="search_bar">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="halign">start</property>
-        <property name="hexpand">False</property>
-        <child>
-          <object class="GtkExpander" id="replace_expander">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="halign">start</property>
-            <property name="valign">center</property>
-            <child>
-              <placeholder/>
-            </child>
-            <child type="label_item">
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="hexpand">True</property>
             <property name="orientation">vertical</property>
+            <property name="spacing">7</property>
             <child>
-              <object class="GtkBox">
+              <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="hexpand">True</property>
-                <property name="spacing">8</property>
                 <child>
-                  <object class="GtkBox">
+                  <object class="GtkSearchEntry" id="search_entry">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_top">5</property>
-                    <property name="margin_bottom">5</property>
-                    <child>
-                      <object class="GtkSearchEntry" id="search_entry">
-                        <property name="width_request">320</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="placeholder_text" translatable="yes">Find</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="go_up_button">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <child>
-                          <object class="GtkImage" id="up_image">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">go-up-symbolic</property>
-                            <property name="icon_size">1</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="go_down_button">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <child>
-                          <object class="GtkImage" id="down_image">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">go-down-symbolic</property>
-                            <property name="icon_size">1</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <style>
-                      <class name="linked"/>
-                    </style>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="width_chars">30</property>
+                    <property name="primary_icon_name">edit-find-symbolic</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="primary_icon_sensitive">False</property>
+                    <property name="placeholder_text" translatable="yes">Find</property>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkGrid">
+                  <object class="GtkButton" id="go_up_button">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
                     <child>
-                      <object class="GtkToggleButton" id="regex_search_togglebutton">
-                        <property name="label" translatable="yes">Regex Search</property>
+                      <object class="GtkImage">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">go-up-symbolic</property>
+                        <property name="icon_size">1</property>
                       </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="pack_type">end</property>
-                    <property name="position">1</property>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="find_status_label">
+                  <object class="GtkButton" id="go_down_button">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">No Results</property>
-                    <property name="width_chars">16</property>
-                    <property name="xalign">0</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">go-down-symbolic</property>
+                        <property name="icon_size">1</property>
+                      </object>
+                    </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="left_attach">2</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToggleButton" id="show_replace_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Switch between Search and Search-and-Replace</property>
+                    <property name="image_position">right</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">edit-find-replace-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">3</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToggleButton" id="show_options_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="focus_on_click">False</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Show or hide search options such as case sensitivity</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">emblem-system-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">4</property>
+                    <property name="top_attach">0</property>
                   </packing>
                 </child>
               </object>
@@ -167,22 +124,23 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkBox">
+                  <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">8</property>
                     <child>
-                      <object class="GtkEntry" id="replace_entry">
-                        <property name="width_request">320</property>
+                      <object class="GtkSearchEntry" id="replace_entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="width_chars">30</property>
                         <property name="primary_icon_name">edit-find-replace-symbolic</property>
+                        <property name="primary_icon_activatable">False</property>
+                        <property name="primary_icon_sensitive">False</property>
                         <property name="placeholder_text" translatable="yes">Replace</property>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                        <property name="width">2</property>
                       </packing>
                     </child>
                     <child>
@@ -193,9 +151,8 @@
                         <property name="receives_default">True</property>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
+                        <property name="left_attach">2</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                     <child>
@@ -204,6 +161,65 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">3</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRevealer" id="option_revealer">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkCheckButton" id="use_regex_button">
+                        <property name="label" translatable="yes">Regular expressions</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="focus_on_click">False</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="case_sensitive_button">
+                        <property name="label" translatable="yes">Case sensitive</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="whole_word_button">
+                        <property name="label" translatable="yes">Match whole word only</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">True</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -217,15 +233,22 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="find_status_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">No Results</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/src/xi_thread.rs
+++ b/src/xi_thread.rs
@@ -22,20 +22,20 @@ impl XiPeer {
     pub fn send_json(&self, v: &Value) {
         self.send(serde_json::to_string(v).unwrap());
     }
-}
 
-pub fn start_xi_thread() -> (XiPeer, Receiver<Value>) {
-    let (to_core_tx, to_core_rx) = unbounded();
-    let to_core_rx = ChanReader(to_core_rx);
-    let (from_core_tx, from_core_rx) = unbounded();
-    let from_core_tx = ChanWriter {
-        sender: from_core_tx,
-    };
-    let mut state = XiCore::new();
-    let mut rpc_looper = RpcLoop::new(from_core_tx);
-    thread::spawn(move || rpc_looper.mainloop(|| to_core_rx, &mut state));
-    let peer = XiPeer { tx: to_core_tx };
-    (peer, from_core_rx)
+    pub fn new() -> (XiPeer, Receiver<Value>) {
+        let (to_core_tx, to_core_rx) = unbounded();
+        let to_core_rx = ChanReader(to_core_rx);
+        let (from_core_tx, from_core_rx) = unbounded();
+        let from_core_tx = ChanWriter {
+            sender: from_core_tx,
+        };
+        let mut state = XiCore::new();
+        let mut rpc_looper = RpcLoop::new(from_core_tx);
+        thread::spawn(move || rpc_looper.mainloop(|| to_core_rx, &mut state));
+        let peer = XiPeer { tx: to_core_tx };
+        (peer, from_core_rx)
+    }
 }
 
 struct ChanReader(Receiver<String>);


### PR DESCRIPTION
This also adds a "whole word" and "case sensitive" option to the Dialog
and generally just makes it plain better.