### PR TITLE
feat(edit_view): keybind Ctrl+Backspace to delete_word_backward

### DIFF
--- a/src/edit_view.rs
+++ b/src/edit_view.rs
@@ -1410,6 +1410,7 @@ impl EditView {
         match ek.get_keyval() {
             key::Delete if norm => self.core.borrow().delete_forward(view_id),
             key::BackSpace if norm => self.core.borrow().delete_backward(view_id),
+            key::BackSpace if ctrl => self.core.borrow().delete_word_backward(view_id),
             key::Return | key::KP_Enter => {
                 self.core.borrow().insert_newline(&view_id);
             }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -220,6 +220,9 @@ impl Core {
     pub fn delete_backward(&self, view_id: &str) {
         self.send_edit_cmd(view_id, "delete_backward", &json!({}))
     }
+    pub fn delete_word_backward(&self, view_id: &str) {
+        self.send_edit_cmd(view_id, "delete_word_backward", &json!({}))
+    }
     pub fn insert_newline(&self, view_id: &str) {
         self.send_edit_cmd(view_id, "insert_newline", &json!({}))
     }


### PR DESCRIPTION
Closes #218

I had to (locally) disable the clippy pre-commit check because of #219, but I ran it manually and it doesn't look like I've committed any sins :).