### PR TITLE
Replace yaourt with yay, because yaourt is not maintained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ repository tracking package
 (including dependencies) the first package can be accomplished with:
 
 ```sh
-yaourt -Sy gxi
+yay -S gxi
 ```
 
 Alternatively use `makepkg`:


### PR DESCRIPTION
Please, do not recommend `yaourt` AUR helper anymore for Arch Linux or Arch-based distributions, because it is not maintained. Use `yay` or `trizen` instead. My pull request includes `yay`.

Sources and discussions about the problem.
https://github.com/archlinuxfr/yaourt/issues/382
https://wiki.archlinux.org/index.php/Talk:AUR_helpers
https://itsfoss.com/best-aur-helpers/
https://wiki.archlinux.org/index.php/AUR_helpers#Comparison_table