### PR TITLE
WIP: refactor(edit_view): use Layout&ScrolledWindow instead of custom Scrollbars

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,6 @@ use glib::MainContext;
 use gtk::Application;
 use log::{debug, info, trace, warn};
 use serde_json::{json, Value};
-use std::cell::RefCell;
 use std::env::args;
 use std::rc::Rc;
 
@@ -159,7 +158,7 @@ fn main() {
         MainWin::new(
             application,
             shared_queue.clone(),
-            Rc::new(RefCell::new(core.clone())),
+            Rc::new(core.clone()),
             xi_config,
            );
     }));

--- a/src/main_win.rs
+++ b/src/main_win.rs
@@ -647,7 +647,7 @@ impl MainWin {
     pub fn handle_save_button(main_win: &Rc<RefCell<Self>>) {
         if let Some(edit_view) = main_win.borrow().get_current_edit_view() {
             if edit_view.borrow().file_name.is_some() {
-                let ev = edit_view.borrow_mut();
+                let ev = edit_view.borrow();
                 let core = main_win.borrow().core.clone();
                 core.borrow()
                     .save(&ev.view_id, ev.file_name.as_ref().unwrap());

--- a/src/main_win.rs
+++ b/src/main_win.rs
@@ -60,7 +60,7 @@ pub struct MainState {
 }
 
 pub struct MainWin {
-    core: Rc<RefCell<Core>>,
+    core: Rc<Core>,
     shared_queue: SharedQueue,
     window: ApplicationWindow,
     notebook: Notebook,
@@ -77,7 +77,7 @@ impl MainWin {
     pub fn new(
         application: &Application,
         shared_queue: SharedQueue,
-        core: Rc<RefCell<Core>>,
+        core: Rc<Core>,
         config: Config,
     ) -> Rc<RefCell<Self>> {
         let glade_src = GLADE_SRC;
@@ -161,7 +161,7 @@ impl MainWin {
                     if let Some(ev) = main_win.borrow().get_current_edit_view() {
                         let core = &main_win.borrow().core;
                         trace!("{} {}", gettext("Setting language to"), &lang);
-                        Self::set_language(&core, &ev.borrow().view_id, &lang);
+                        Self::set_language(core, &ev.borrow().view_id, &lang);
                     }
                 }
             });
@@ -413,7 +413,6 @@ impl MainWin {
         }
 
         self.core
-            .borrow()
             .send_notification("set_theme", &json!({ "theme_name": state.theme_name }));
     }
 
@@ -571,7 +570,6 @@ impl MainWin {
 
             if let Some(id) = id {
                 self.core
-                    .borrow()
                     .send_result(id, &serde_json::to_value(vec![widths]).unwrap());
             }
         }
@@ -599,9 +597,9 @@ impl MainWin {
         }
     }
 
-    pub fn set_language(core: &Rc<RefCell<Core>>, view_id: &str, lang: &str) {
+    pub fn set_language(core: &Rc<Core>, view_id: &str, lang: &str) {
         debug!("{} '{:?}'", gettext("Changing language to"), lang);
-        core.borrow().set_language(&view_id, &lang);
+        core.set_language(&view_id, &lang);
     }
 
     /// Display the FileChooserNative for opening, send the result to the Xi core.
@@ -649,8 +647,7 @@ impl MainWin {
             if edit_view.borrow().file_name.is_some() {
                 let ev = edit_view.borrow();
                 let core = main_win.borrow().core.clone();
-                core.borrow()
-                    .save(&ev.view_id, ev.file_name.as_ref().unwrap());
+                core.save(&ev.view_id, ev.file_name.as_ref().unwrap());
             } else {
                 Self::save_as(main_win, &edit_view);
             }
@@ -695,7 +692,7 @@ impl MainWin {
                                 debug!("{} {:?}", gettext("Saving file"), &file);
                                 let view_id = edit_view.borrow().view_id.clone();
                                 let file = file.to_string_lossy();
-                                win.core.borrow().save(&view_id, &file);
+                                win.core.save(&view_id, &file);
                                 edit_view.borrow_mut().set_file(&file);
                             }
                         Err(e) => {
@@ -764,15 +761,13 @@ impl MainWin {
 
         let shared_queue = self.shared_queue.clone();
         let file_name2 = file_name.map(std::string::ToString::to_string);
-        self.core
-            .borrow_mut()
-            .send_request("new_view", &params, move |value| {
-                let value = value.clone();
-                shared_queue.add_core_msg(CoreMsg::NewViewReply {
-                    file_name: file_name2,
-                    value,
-                })
-            });
+        self.core.send_request("new_view", &params, move |value| {
+            let value = value.clone();
+            shared_queue.add_core_msg(CoreMsg::NewViewReply {
+                file_name: file_name2,
+                value,
+            })
+        });
     }
 
     fn new_view_response(main_win: &Rc<RefCell<Self>>, file_name: Option<String>, value: &Value) {
@@ -815,7 +810,7 @@ impl MainWin {
                     &win.core,
                     &hamburger_button,
                     file_name,
-                    view_id,
+                    view_id.to_string(),
                     &win.window,
                 );
                 {
@@ -970,7 +965,7 @@ impl MainWin {
             }
             main_win.view_id_to_w.remove(&view_id);
             main_win.views.remove(&view_id);
-            main_win.core.borrow().close_view(&view_id);
+            main_win.core.close_view(&view_id);
         }
         save_action
     }

--- a/src/prefs_win.rs
+++ b/src/prefs_win.rs
@@ -10,7 +10,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 pub struct PrefsWin {
-    core: Rc<RefCell<Core>>,
+    core: Rc<Core>,
     window: Window,
 }
 
@@ -18,7 +18,7 @@ impl PrefsWin {
     pub fn new(
         parent: &ApplicationWindow,
         main_state: &Rc<RefCell<MainState>>,
-        core: &Rc<RefCell<Core>>,
+        core: &Rc<Core>,
         edit_view: Option<Rc<RefCell<EditView>>>,
     ) -> Rc<RefCell<Self>> {
         const SRC: &str = include_str!("ui/prefs_win.glade");
@@ -92,7 +92,6 @@ impl PrefsWin {
         theme_combo_box.connect_changed(clone!(core, main_state => move |cb|{
             if let Some(theme_name) = cb.get_active_text() {
                 debug!("{} {:?}", gettext("Theme changed to"), &theme_name);
-                let core = core.borrow();
                 core.set_theme(&theme_name);
 
                 crate::pref_storage::set_theme_schema(theme_name.to_string());

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -446,7 +446,7 @@ impl Core {
         self.send_edit_cmd(view_id, "redo", &json!({}))
     }
 
-    pub fn cut(&mut self, view_id: &str, clipboard_rx: glib::Sender<Option<String>>) {
+    pub fn cut(&self, view_id: &str, clipboard_rx: glib::Sender<Option<String>>) {
         self.send_request(
             "edit",
             &json!({
@@ -464,7 +464,7 @@ impl Core {
         );
     }
 
-    pub fn copy(&mut self, view_id: &str, clipboard_rx: glib::Sender<Option<String>>) {
+    pub fn copy(&self, view_id: &str, clipboard_rx: glib::Sender<Option<String>>) {
         self.send_request(
             "edit",
             &json!({

--- a/src/ui/ev.glade
+++ b/src/ui/ev.glade
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkAdjustment" id="hadj">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="vadj">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkBox" id="ev_root_widget">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkDrawingArea" id="line_count">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkDrawingArea" id="edit_area">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrollbar" id="horiz_bar">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="adjustment">hadj</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkScrollbar" id="vert_bar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="adjustment">vadj</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
This spares us from messing around with the Scrollbars other than when the
cursor moves out of the view.

fixes #227