### PR TITLE
remove local paths, and allow custom xi-core

### DIFF
--- a/src/editview/Cargo.toml
+++ b/src/editview/Cargo.toml
@@ -34,4 +34,4 @@ serde_derive = "1"
 serde_json = "1"
 syntect = "3"
 tokio = "0.1"
-xrl = { path="/home/rasmus/Projects/xrl" }
+xrl = { git = "https://github.com/Cogitri/xrl.git", branch = "gxi-changes" }

--- a/src/gxi/Cargo.toml
+++ b/src/gxi/Cargo.toml
@@ -42,7 +42,7 @@ serde_derive = "1"
 serde_json = "1"
 syntect = "3"
 tokio = "0.1.20"
-xrl = { path="/home/rasmus/Projects/xrl" }
+xrl = { git = "https://github.com/Cogitri/xrl.git", branch = "gxi-changes" }
 
 [dev-dependencies]
 cargo-husky = { version="1", default-features = false, features = ["user-hooks"] }

--- a/src/gxi/src/main.rs
+++ b/src/gxi/src/main.rs
@@ -149,8 +149,11 @@ fn main() {
                 Err(TextDomainError::InvalidLocale(locale)) => warn!("Invalid locale {}", locale),
             }
 
-            // Start xi-editor
-            tokio::run(core.client_started(None, crate::globals::PLUGIN_DIR).map_err(|_|()));
+            let xi_config_dir = std::env::var("XI_CONFIG_DIR").ok();
+            tokio::run(
+                core.client_started(
+                    xi_config_dir.as_ref().map(String::as_str),
+                    crate::globals::PLUGIN_DIR).map_err(|_|()));
 
             setup_config(&core);
 


### PR DESCRIPTION
I'm looking at https://github.com/xi-frontend/xrl/issues/27 and I needed those changes to compile. This was necessary to have xi-core find syntect. FWIW I'm compiling with that:

```shell
git clean -xfd                    

export XI_CONFIG_DIR="${PWD}/build/xi-core"
mkdir -p "${XI_CONFIG_DIR}"
cargo install --path vendor/xi-editor/rust --root "${XI_CONFIG_DIR}"
make -C vendor/xi-editor/rust/syntect-plugin install

export PATH="${XI_CONFIG_DIR}/bin:${XI_CONFIG_DIR}/plugins/syntect/bin:${PATH}"
export GXI_PLUGIN_DIR="${XI_CONFIG_DIR}/plugins"
export GSETTINGS_SCHEMA_DIR=data
glib-compile-schemas data
cargo build
RUST_LOG=info cargo run
```